### PR TITLE
add hpflex example

### DIFF
--- a/BrickModelInterface/get_metadata.py
+++ b/BrickModelInterface/get_metadata.py
@@ -262,7 +262,7 @@ class BuildingMetadataLoader:
             "tz": self._get_value(self.site, BRICK.timezone),
             "latitude": self._get_value(self.site, BRICK.latitude),
             "longitude": self._get_value(self.site, BRICK.longitude),
-            "NOAAstation": self._get_value(self.site, self.HPF.hasNOAAStation),
+            "NOAAstation": self._get_value(self.site, BRICK.hasNOAAStation),
             # project_id and site_id are currently the same
             "project_id": next(self.g.triples((None,RDF.type, BRICK.Site)))[0],
             "site_id": next(self.g.triples((None,RDF.type, BRICK.Site)))[0],
@@ -311,7 +311,7 @@ class BuildingMetadataLoader:
         # TODO: Add error messages for when zone is or isn't present
         for tstat, zone in tstats_zones:
         # Method for filtering depends on if URIs should be used elsewere, can just use id, and not namespace if that is more suitable
-            if (for_zone != None) & (self.g.compute_qname(zone)[-1] != for_zone):
+            if (for_zone is not None) & (self.g.compute_qname(zone)[-1] != for_zone):
                 continue
         #     MPC configuration should be separate, but can determine defaults based on whether heat/cool are electric
         #     thermostat_data["heat_availability"].append(self._get_value(tstat, self.HPF.isHeatAvailable))

--- a/tutorial/bldg1.ttl
+++ b/tutorial/bldg1.ttl
@@ -1,0 +1,283 @@
+@prefix bldg: <urn:hpflex/hpflex_demo#> .
+@prefix brick: <https://brickschema.org/schema/Brick#> .
+@prefix hpflex: <urn:hpflex#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+bldg: a owl:Ontology,
+        hpflex:Project .
+
+bldg:hpflex_demo a brick:Site ;
+    brick:hasNOAAStation bldg:hpflex_demo.noaastation ;
+    brick:latitude bldg:hpflex_demo.latitude ;
+    brick:longitude bldg:hpflex_demo.longitude ;
+    brick:timezone bldg:hpflex_demo.timezone .
+
+bldg:hpflex_demo.latitude qudt:hasQuantityKind quantitykind:Latitude ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 3.787913e+01 .
+
+bldg:hpflex_demo.longitude qudt:hasQuantityKind quantitykind:Longitude ;
+    qudt:hasUnit unit:Degree ;
+    brick:value -1.222544e+02 .
+
+bldg:hpflex_demo.noaastation hpflex:hasNOAAStation "" .
+
+bldg:hpflex_demo.timezone qudt:hasUnit unit:Timezone ;
+    brick:value "US/Pacific" .
+
+bldg:space_1_1 a brick:Space ;
+    brick:area bldg:space_1_1_area ;
+    brick:isPartOf bldg:zone_1 .
+
+bldg:space_1_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.3e+03 .
+
+bldg:space_2_1 a brick:Space ;
+    brick:area bldg:space_2_1_area ;
+    brick:isPartOf bldg:zone_2 .
+
+bldg:space_2_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.3e+03 .
+
+bldg:space_3_1 a brick:Space ;
+    brick:area bldg:space_3_1_area ;
+    brick:isPartOf bldg:zone_3 .
+
+bldg:space_3_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.3e+03 .
+
+bldg:tstat_zone_1_active a brick:Availability_Status ;
+    brick:isPointOf bldg:tstat_zone_1 ;
+    brick:value true .
+
+bldg:tstat_zone_1_resolution qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:value "float" .
+
+bldg:tstat_zone_1_setpoint_deadband a brick:Temperature_Deadband_Setpoint ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_1 ;
+    brick:value 5e-01 .
+
+bldg:tstat_zone_1_stage_count qudt:hasQuantityKind quantitykind:Count ;
+    qudt:hasUnit unit:NUM ;
+    brick:value 4 .
+
+bldg:tstat_zone_1_tolerance a brick:Temperature_Tolerance_Parameter ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_1 ;
+    brick:value 5e-01 .
+
+bldg:tstat_zone_2_active a brick:Availability_Status ;
+    brick:isPointOf bldg:tstat_zone_2 ;
+    brick:value true .
+
+bldg:tstat_zone_2_resolution qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:value "float" .
+
+bldg:tstat_zone_2_setpoint_deadband a brick:Temperature_Deadband_Setpoint ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_2 ;
+    brick:value 5e-01 .
+
+bldg:tstat_zone_2_stage_count qudt:hasQuantityKind quantitykind:Count ;
+    qudt:hasUnit unit:NUM ;
+    brick:value 4 .
+
+bldg:tstat_zone_2_tolerance a brick:Temperature_Tolerance_Parameter ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_2 ;
+    brick:value 5e-01 .
+
+bldg:tstat_zone_3_active a brick:Availability_Status ;
+    brick:isPointOf bldg:tstat_zone_3 ;
+    brick:value true .
+
+bldg:tstat_zone_3_resolution qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:value "float" .
+
+bldg:tstat_zone_3_setpoint_deadband a brick:Temperature_Deadband_Setpoint ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_3 ;
+    brick:value 5e-01 .
+
+bldg:tstat_zone_3_stage_count qudt:hasQuantityKind quantitykind:Count ;
+    qudt:hasUnit unit:NUM ;
+    brick:value 4 .
+
+bldg:tstat_zone_3_tolerance a brick:Temperature_Tolerance_Parameter ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_3 ;
+    brick:value 5e-01 .
+
+bldg:window_1_1 a brick:Window ;
+    brick:area bldg:window_1_1_area ;
+    brick:azimuth bldg:window_1_1_azimuth ;
+    brick:isPartOf bldg:zone_1 ;
+    brick:tilt bldg:window_1_1_tilt .
+
+bldg:window_1_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.5e+02 .
+
+bldg:window_1_1_azimuth qudt:hasQuantityKind quantitykind:Azimuth ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 1.8e+02 .
+
+bldg:window_1_1_tilt qudt:hasQuantityKind quantitykind:Tilt ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 9e+01 .
+
+bldg:window_2_1 a brick:Window ;
+    brick:area bldg:window_2_1_area ;
+    brick:azimuth bldg:window_2_1_azimuth ;
+    brick:isPartOf bldg:zone_2 ;
+    brick:tilt bldg:window_2_1_tilt .
+
+bldg:window_2_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 8e+01 .
+
+bldg:window_2_1_azimuth qudt:hasQuantityKind quantitykind:Azimuth ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 1.8e+02 .
+
+bldg:window_2_1_tilt qudt:hasQuantityKind quantitykind:Tilt ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 9e+01 .
+
+bldg:window_2_2 a brick:Window ;
+    brick:area bldg:window_2_2_area ;
+    brick:azimuth bldg:window_2_2_azimuth ;
+    brick:isPartOf bldg:zone_2 ;
+    brick:tilt bldg:window_2_2_tilt .
+
+bldg:window_2_2_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 8e+01 .
+
+bldg:window_2_2_azimuth qudt:hasQuantityKind quantitykind:Azimuth ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 1.8e+02 .
+
+bldg:window_2_2_tilt qudt:hasQuantityKind quantitykind:Tilt ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 9e+01 .
+
+bldg:window_3_1 a brick:Window ;
+    brick:area bldg:window_3_1_area ;
+    brick:azimuth bldg:window_3_1_azimuth ;
+    brick:isPartOf bldg:zone_3 ;
+    brick:tilt bldg:window_3_1_tilt .
+
+bldg:window_3_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 5e+01 .
+
+bldg:window_3_1_azimuth qudt:hasQuantityKind quantitykind:Azimuth ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 1.8e+02 .
+
+bldg:window_3_1_tilt qudt:hasQuantityKind quantitykind:Tilt ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 9e+01 .
+
+bldg:window_3_2 a brick:Window ;
+    brick:area bldg:window_3_2_area ;
+    brick:azimuth bldg:window_3_2_azimuth ;
+    brick:isPartOf bldg:zone_3 ;
+    brick:tilt bldg:window_3_2_tilt .
+
+bldg:window_3_2_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 5e+01 .
+
+bldg:window_3_2_azimuth qudt:hasQuantityKind quantitykind:Azimuth ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 1.8e+02 .
+
+bldg:window_3_2_tilt qudt:hasQuantityKind quantitykind:Tilt ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 9e+01 .
+
+bldg:window_3_3 a brick:Window ;
+    brick:area bldg:window_3_3_area ;
+    brick:azimuth bldg:window_3_3_azimuth ;
+    brick:isPartOf bldg:zone_3 ;
+    brick:tilt bldg:window_3_3_tilt .
+
+bldg:window_3_3_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 5e+01 .
+
+bldg:window_3_3_azimuth qudt:hasQuantityKind quantitykind:Azimuth ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 1.8e+02 .
+
+bldg:window_3_3_tilt qudt:hasQuantityKind quantitykind:Tilt ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 9e+01 .
+
+bldg:zone_1 a brick:HVAC_Zone ;
+    brick:hasPart bldg:space_1_1,
+        bldg:window_1_1 ;
+    brick:isLocationOf bldg:tstat_zone_1 .
+
+bldg:tstat_zone_1 a brick:Thermostat ;
+    brick:hasLocation bldg:zone_1 ;
+    brick:hasPoint bldg:tstat_zone_1_active,
+        bldg:tstat_zone_1_setpoint_deadband,
+        bldg:tstat_zone_1_tolerance ;
+    brick:operationalStageCount bldg:tstat_zone_1_stage_count ;
+    brick:resolution bldg:tstat_zone_1_resolution .
+
+bldg:tstat_zone_2 a brick:Thermostat ;
+    brick:hasLocation bldg:zone_2 ;
+    brick:hasPoint bldg:tstat_zone_2_active,
+        bldg:tstat_zone_2_setpoint_deadband,
+        bldg:tstat_zone_2_tolerance ;
+    brick:operationalStageCount bldg:tstat_zone_2_stage_count ;
+    brick:resolution bldg:tstat_zone_2_resolution .
+
+bldg:tstat_zone_3 a brick:Thermostat ;
+    brick:hasLocation bldg:zone_3 ;
+    brick:hasPoint bldg:tstat_zone_3_active,
+        bldg:tstat_zone_3_setpoint_deadband,
+        bldg:tstat_zone_3_tolerance ;
+    brick:operationalStageCount bldg:tstat_zone_3_stage_count ;
+    brick:resolution bldg:tstat_zone_3_resolution .
+
+bldg:zone_2 a brick:HVAC_Zone ;
+    brick:hasPart bldg:space_2_1,
+        bldg:window_2_1,
+        bldg:window_2_2 ;
+    brick:isLocationOf bldg:tstat_zone_2 .
+
+bldg:zone_3 a brick:HVAC_Zone ;
+    brick:hasPart bldg:space_3_1,
+        bldg:window_3_1,
+        bldg:window_3_2,
+        bldg:window_3_3 ;
+    brick:isLocationOf bldg:tstat_zone_3 .
+

--- a/tutorial/bldg2.ttl
+++ b/tutorial/bldg2.ttl
@@ -1,0 +1,291 @@
+@prefix bldg: <urn:hpflex/hpflex_demo#> .
+@prefix brick: <https://brickschema.org/schema/Brick#> .
+@prefix hpflex: <urn:hpflex#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+bldg: a owl:Ontology,
+        hpflex:Project .
+
+bldg:hpflex_demo a brick:Site ;
+    brick:hasNOAAStation bldg:hpflex_demo.noaastation ;
+    brick:latitude bldg:hpflex_demo.latitude ;
+    brick:longitude bldg:hpflex_demo.longitude ;
+    brick:timezone bldg:hpflex_demo.timezone .
+
+bldg:hpflex_demo.latitude qudt:hasQuantityKind quantitykind:Latitude ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 3.787913e+01 .
+
+bldg:hpflex_demo.longitude qudt:hasQuantityKind quantitykind:Longitude ;
+    qudt:hasUnit unit:Degree ;
+    brick:value -1.222544e+02 .
+
+bldg:hpflex_demo.noaastation hpflex:hasNOAAStation "" .
+
+bldg:hpflex_demo.timezone qudt:hasUnit unit:Timezone ;
+    brick:value "US/Pacific" .
+
+bldg:space_1_1 a brick:Space ;
+    brick:area bldg:space_1_1_area ;
+    brick:isPartOf bldg:zone_1 .
+
+bldg:space_1_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.5e+03 .
+
+bldg:space_2_1 a brick:Space ;
+    brick:area bldg:space_2_1_area ;
+    brick:isPartOf bldg:zone_2 .
+
+bldg:space_2_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.5e+03 .
+
+bldg:space_3_1 a brick:Space ;
+    brick:area bldg:space_3_1_area ;
+    brick:isPartOf bldg:zone_3 .
+
+bldg:space_3_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.5e+03 .
+
+bldg:space_4_1 a brick:Space ;
+    brick:area bldg:space_4_1_area ;
+    brick:isPartOf bldg:zone_4 .
+
+bldg:space_4_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.5e+03 .
+
+bldg:tstat_zone_1_active a brick:Availability_Status ;
+    brick:isPointOf bldg:tstat_zone_1 ;
+    brick:value true .
+
+bldg:tstat_zone_1_resolution qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:value "float" .
+
+bldg:tstat_zone_1_setpoint_deadband a brick:Temperature_Deadband_Setpoint ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_1 ;
+    brick:value 4e+00 .
+
+bldg:tstat_zone_1_stage_count qudt:hasQuantityKind quantitykind:Count ;
+    qudt:hasUnit unit:NUM ;
+    brick:value 1 .
+
+bldg:tstat_zone_1_tolerance a brick:Temperature_Tolerance_Parameter ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_1 ;
+    brick:value 5e-01 .
+
+bldg:tstat_zone_2_active a brick:Availability_Status ;
+    brick:isPointOf bldg:tstat_zone_2 ;
+    brick:value true .
+
+bldg:tstat_zone_2_resolution qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:value "float" .
+
+bldg:tstat_zone_2_setpoint_deadband a brick:Temperature_Deadband_Setpoint ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_2 ;
+    brick:value 4e+00 .
+
+bldg:tstat_zone_2_stage_count qudt:hasQuantityKind quantitykind:Count ;
+    qudt:hasUnit unit:NUM ;
+    brick:value 1 .
+
+bldg:tstat_zone_2_tolerance a brick:Temperature_Tolerance_Parameter ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_2 ;
+    brick:value 5e-01 .
+
+bldg:tstat_zone_3_active a brick:Availability_Status ;
+    brick:isPointOf bldg:tstat_zone_3 ;
+    brick:value true .
+
+bldg:tstat_zone_3_resolution qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:value "float" .
+
+bldg:tstat_zone_3_setpoint_deadband a brick:Temperature_Deadband_Setpoint ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_3 ;
+    brick:value 4e+00 .
+
+bldg:tstat_zone_3_stage_count qudt:hasQuantityKind quantitykind:Count ;
+    qudt:hasUnit unit:NUM ;
+    brick:value 1 .
+
+bldg:tstat_zone_3_tolerance a brick:Temperature_Tolerance_Parameter ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_3 ;
+    brick:value 5e-01 .
+
+bldg:tstat_zone_4_active a brick:Availability_Status ;
+    brick:isPointOf bldg:tstat_zone_4 ;
+    brick:value true .
+
+bldg:tstat_zone_4_resolution qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:value "float" .
+
+bldg:tstat_zone_4_setpoint_deadband a brick:Temperature_Deadband_Setpoint ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_4 ;
+    brick:value 4e+00 .
+
+bldg:tstat_zone_4_stage_count qudt:hasQuantityKind quantitykind:Count ;
+    qudt:hasUnit unit:NUM ;
+    brick:value 1 .
+
+bldg:tstat_zone_4_tolerance a brick:Temperature_Tolerance_Parameter ;
+    qudt:hasQuantityKind quantitykind:Temperature ;
+    qudt:hasUnit unit:DEG_F ;
+    qudt:isDeltaQuantity true ;
+    brick:isPointOf bldg:tstat_zone_4 ;
+    brick:value 5e-01 .
+
+bldg:window_1_1 a brick:Window ;
+    brick:area bldg:window_1_1_area ;
+    brick:azimuth bldg:window_1_1_azimuth ;
+    brick:isPartOf bldg:zone_1 ;
+    brick:tilt bldg:window_1_1_tilt .
+
+bldg:window_1_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.5e+02 .
+
+bldg:window_1_1_azimuth qudt:hasQuantityKind quantitykind:Azimuth ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 1.8e+02 .
+
+bldg:window_1_1_tilt qudt:hasQuantityKind quantitykind:Tilt ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 9e+01 .
+
+bldg:window_2_1 a brick:Window ;
+    brick:area bldg:window_2_1_area ;
+    brick:azimuth bldg:window_2_1_azimuth ;
+    brick:isPartOf bldg:zone_2 ;
+    brick:tilt bldg:window_2_1_tilt .
+
+bldg:window_2_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.5e+02 .
+
+bldg:window_2_1_azimuth qudt:hasQuantityKind quantitykind:Azimuth ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 1.8e+02 .
+
+bldg:window_2_1_tilt qudt:hasQuantityKind quantitykind:Tilt ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 9e+01 .
+
+bldg:window_3_1 a brick:Window ;
+    brick:area bldg:window_3_1_area ;
+    brick:azimuth bldg:window_3_1_azimuth ;
+    brick:isPartOf bldg:zone_3 ;
+    brick:tilt bldg:window_3_1_tilt .
+
+bldg:window_3_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.5e+02 .
+
+bldg:window_3_1_azimuth qudt:hasQuantityKind quantitykind:Azimuth ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 1.8e+02 .
+
+bldg:window_3_1_tilt qudt:hasQuantityKind quantitykind:Tilt ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 9e+01 .
+
+bldg:window_4_1 a brick:Window ;
+    brick:area bldg:window_4_1_area ;
+    brick:azimuth bldg:window_4_1_azimuth ;
+    brick:isPartOf bldg:zone_4 ;
+    brick:tilt bldg:window_4_1_tilt .
+
+bldg:window_4_1_area qudt:hasQuantityKind quantitykind:Area ;
+    qudt:hasUnit unit:FT2 ;
+    brick:value 1.5e+02 .
+
+bldg:window_4_1_azimuth qudt:hasQuantityKind quantitykind:Azimuth ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 1.8e+02 .
+
+bldg:window_4_1_tilt qudt:hasQuantityKind quantitykind:Tilt ;
+    qudt:hasUnit unit:Degree ;
+    brick:value 9e+01 .
+
+bldg:zone_1 a brick:HVAC_Zone ;
+    brick:hasPart bldg:space_1_1,
+        bldg:window_1_1 ;
+    brick:isLocationOf bldg:tstat_zone_1 .
+
+bldg:zone_2 a brick:HVAC_Zone ;
+    brick:hasPart bldg:space_2_1,
+        bldg:window_2_1 ;
+    brick:isLocationOf bldg:tstat_zone_2 .
+
+bldg:zone_3 a brick:HVAC_Zone ;
+    brick:hasPart bldg:space_3_1,
+        bldg:window_3_1 ;
+    brick:isLocationOf bldg:tstat_zone_3 .
+
+bldg:zone_4 a brick:HVAC_Zone ;
+    brick:hasPart bldg:space_4_1,
+        bldg:window_4_1 ;
+    brick:isLocationOf bldg:tstat_zone_4 .
+
+bldg:tstat_zone_1 a brick:Thermostat ;
+    brick:hasLocation bldg:zone_1 ;
+    brick:hasPoint bldg:tstat_zone_1_active,
+        bldg:tstat_zone_1_setpoint_deadband,
+        bldg:tstat_zone_1_tolerance ;
+    brick:operationalStageCount bldg:tstat_zone_1_stage_count ;
+    brick:resolution bldg:tstat_zone_1_resolution .
+
+bldg:tstat_zone_2 a brick:Thermostat ;
+    brick:hasLocation bldg:zone_2 ;
+    brick:hasPoint bldg:tstat_zone_2_active,
+        bldg:tstat_zone_2_setpoint_deadband,
+        bldg:tstat_zone_2_tolerance ;
+    brick:operationalStageCount bldg:tstat_zone_2_stage_count ;
+    brick:resolution bldg:tstat_zone_2_resolution .
+
+bldg:tstat_zone_3 a brick:Thermostat ;
+    brick:hasLocation bldg:zone_3 ;
+    brick:hasPoint bldg:tstat_zone_3_active,
+        bldg:tstat_zone_3_setpoint_deadband,
+        bldg:tstat_zone_3_tolerance ;
+    brick:operationalStageCount bldg:tstat_zone_3_stage_count ;
+    brick:resolution bldg:tstat_zone_3_resolution .
+
+bldg:tstat_zone_4 a brick:Thermostat ;
+    brick:hasLocation bldg:zone_4 ;
+    brick:hasPoint bldg:tstat_zone_4_active,
+        bldg:tstat_zone_4_setpoint_deadband,
+        bldg:tstat_zone_4_tolerance ;
+    brick:operationalStageCount bldg:tstat_zone_4_stage_count ;
+    brick:resolution bldg:tstat_zone_4_resolution .
+

--- a/tutorial/metadata-survey-hpflex/easy-config-test/config.json
+++ b/tutorial/metadata-survey-hpflex/easy-config-test/config.json
@@ -1,0 +1,43 @@
+{
+    "site_name": "easy-config-test",
+    "hvac_type": "hp-rtu",
+    "hvacs_feed_hvacs": {},
+    "hvacs_feed_zones": {
+        "hvac_1": [
+            "zone_1"
+        ],
+        "hvac_2": [
+            "zone_2"
+        ],
+        "hvac_3": [
+            "zone_3"
+        ]
+    },
+    "zones_contain_spaces": {
+        "zone_1": [
+            "space_1_1",
+            "space_1_2"
+        ],
+        "zone_2": [
+            "space_2_1"
+        ],
+        "zone_3": [
+            "space_3_1"
+        ]
+    },
+    "zones_contain_windows": {
+        "zone_1": [
+            "window_1_1",
+            "window_1_2"
+        ],
+        "zone_2": [
+            "window_2_1",
+            "window_2_2"
+        ],
+        "zone_3": [
+            "window_3_1",
+            "window_3_2",
+            "window_3_3"
+        ]
+    }
+}

--- a/tutorial/metadata-survey-hpflex/easy-config-test/hvac/hvac_units.csv
+++ b/tutorial/metadata-survey-hpflex/easy-config-test/hvac/hvac_units.csv
@@ -1,0 +1,4 @@
+hvac_id,zone_id,cooling_capacity,heating_capacity,cooling_cop,heating_cop
+hvac_1,zone_1,,,,
+hvac_2,zone_2,,,,
+hvac_3,zone_3,,,,

--- a/tutorial/metadata-survey-hpflex/easy-config-test/point_list.csv
+++ b/tutorial/metadata-survey-hpflex/easy-config-test/point_list.csv
@@ -1,0 +1,1 @@
+point_of,point_type,point_name,quantitykind,unit

--- a/tutorial/metadata-survey-hpflex/easy-config-test/site_info.csv
+++ b/tutorial/metadata-survey-hpflex/easy-config-test/site_info.csv
@@ -1,0 +1,2 @@
+site_id,timezone,latitude,longitude,noaa_station
+easy-config-test,,,,

--- a/tutorial/metadata-survey-hpflex/easy-config-test/spaces/zone_1_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/easy-config-test/spaces/zone_1_spaces.csv
@@ -1,0 +1,3 @@
+space_id,zone_id,area_value,area_unit
+space_1_1,zone_1,,FT2
+space_1_2,zone_1,,FT2

--- a/tutorial/metadata-survey-hpflex/easy-config-test/spaces/zone_2_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/easy-config-test/spaces/zone_2_spaces.csv
@@ -1,0 +1,2 @@
+space_id,zone_id,area_value,area_unit
+space_2_1,zone_2,,FT2

--- a/tutorial/metadata-survey-hpflex/easy-config-test/spaces/zone_3_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/easy-config-test/spaces/zone_3_spaces.csv
@@ -1,0 +1,2 @@
+space_id,zone_id,area_value,area_unit
+space_3_1,zone_3,,FT2

--- a/tutorial/metadata-survey-hpflex/easy-config-test/windows/zone_1_windows.csv
+++ b/tutorial/metadata-survey-hpflex/easy-config-test/windows/zone_1_windows.csv
@@ -1,0 +1,3 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_1_1,zone_1,,,,FT2
+window_1_2,zone_1,,,,FT2

--- a/tutorial/metadata-survey-hpflex/easy-config-test/windows/zone_2_windows.csv
+++ b/tutorial/metadata-survey-hpflex/easy-config-test/windows/zone_2_windows.csv
@@ -1,0 +1,3 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_2_1,zone_2,,,,FT2
+window_2_2,zone_2,,,,FT2

--- a/tutorial/metadata-survey-hpflex/easy-config-test/windows/zone_3_windows.csv
+++ b/tutorial/metadata-survey-hpflex/easy-config-test/windows/zone_3_windows.csv
@@ -1,0 +1,4 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_3_1,zone_3,,,,FT2
+window_3_2,zone_3,,,,FT2
+window_3_3,zone_3,,,,FT2

--- a/tutorial/metadata-survey-hpflex/easy-config-test/zones/zones.csv
+++ b/tutorial/metadata-survey-hpflex/easy-config-test/zones/zones.csv
@@ -1,0 +1,4 @@
+tstat_id,zone_id,stage_count,setpoint_deadband,tolerance,active,resolution,temperature_unit
+tstat_zone_1,zone_1,,,,DEG_F
+tstat_zone_2,zone_2,,,,DEG_F
+tstat_zone_3,zone_3,,,,DEG_F

--- a/tutorial/metadata-survey-hpflex/filled-easy-config-test/config.json
+++ b/tutorial/metadata-survey-hpflex/filled-easy-config-test/config.json
@@ -1,0 +1,43 @@
+{
+    "site_name": "easy-config-test",
+    "hvac_type": "hp-rtu",
+    "hvacs_feed_hvacs": {},
+    "hvacs_feed_zones": {
+        "hvac_1": [
+            "zone_1"
+        ],
+        "hvac_2": [
+            "zone_2"
+        ],
+        "hvac_3": [
+            "zone_3"
+        ]
+    },
+    "zones_contain_spaces": {
+        "zone_1": [
+            "space_1_1",
+            "space_1_2"
+        ],
+        "zone_2": [
+            "space_2_1"
+        ],
+        "zone_3": [
+            "space_3_1"
+        ]
+    },
+    "zones_contain_windows": {
+        "zone_1": [
+            "window_1_1",
+            "window_1_2"
+        ],
+        "zone_2": [
+            "window_2_1",
+            "window_2_2"
+        ],
+        "zone_3": [
+            "window_3_1",
+            "window_3_2",
+            "window_3_3"
+        ]
+    }
+}

--- a/tutorial/metadata-survey-hpflex/filled-easy-config-test/hvac/hvac_units.csv
+++ b/tutorial/metadata-survey-hpflex/filled-easy-config-test/hvac/hvac_units.csv
@@ -1,0 +1,4 @@
+hvac_id,zone_id,cooling_capacity,heating_capacity,cooling_cop,heating_cop
+hvac_1,zone_1,,,,
+hvac_2,zone_2,,,,
+hvac_3,zone_3,,,,

--- a/tutorial/metadata-survey-hpflex/filled-easy-config-test/point_list.csv
+++ b/tutorial/metadata-survey-hpflex/filled-easy-config-test/point_list.csv
@@ -1,0 +1,1 @@
+point_of,point_type,point_name,quantitykind,unit

--- a/tutorial/metadata-survey-hpflex/filled-easy-config-test/site_info.csv
+++ b/tutorial/metadata-survey-hpflex/filled-easy-config-test/site_info.csv
@@ -1,0 +1,2 @@
+site_id,timezone,latitude,longitude,noaa_station
+easy-config-test,US/Pacific,37.879134,-122.254433,

--- a/tutorial/metadata-survey-hpflex/filled-easy-config-test/spaces/zone_1_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/filled-easy-config-test/spaces/zone_1_spaces.csv
@@ -1,0 +1,3 @@
+space_id,zone_id,area_value,area_unit
+space_1_1,zone_1,,FT2
+space_1_2,zone_1,,FT2

--- a/tutorial/metadata-survey-hpflex/filled-easy-config-test/spaces/zone_2_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/filled-easy-config-test/spaces/zone_2_spaces.csv
@@ -1,0 +1,2 @@
+space_id,zone_id,area_value,area_unit
+space_2_1,zone_2,,FT2

--- a/tutorial/metadata-survey-hpflex/filled-easy-config-test/spaces/zone_3_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/filled-easy-config-test/spaces/zone_3_spaces.csv
@@ -1,0 +1,2 @@
+space_id,zone_id,area_value,area_unit
+space_3_1,zone_3,,FT2

--- a/tutorial/metadata-survey-hpflex/filled-easy-config-test/windows/zone_1_windows.csv
+++ b/tutorial/metadata-survey-hpflex/filled-easy-config-test/windows/zone_1_windows.csv
@@ -1,0 +1,3 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_1_1,zone_1,,,,FT2
+window_1_2,zone_1,,,,FT2

--- a/tutorial/metadata-survey-hpflex/filled-easy-config-test/windows/zone_2_windows.csv
+++ b/tutorial/metadata-survey-hpflex/filled-easy-config-test/windows/zone_2_windows.csv
@@ -1,0 +1,3 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_2_1,zone_2,,,,FT2
+window_2_2,zone_2,,,,FT2

--- a/tutorial/metadata-survey-hpflex/filled-easy-config-test/windows/zone_3_windows.csv
+++ b/tutorial/metadata-survey-hpflex/filled-easy-config-test/windows/zone_3_windows.csv
@@ -1,0 +1,4 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_3_1,zone_3,,,,FT2
+window_3_2,zone_3,,,,FT2
+window_3_3,zone_3,,,,FT2

--- a/tutorial/metadata-survey-hpflex/filled-easy-config-test/zones/zones.csv
+++ b/tutorial/metadata-survey-hpflex/filled-easy-config-test/zones/zones.csv
@@ -1,0 +1,5 @@
+tstat_id,zone_id,stage_count,setpoint_deadband,tolerance,active,resolution,temperature_unit
+tstat_zone_1,zone_1,,,,DEG_F,,
+tstat_zone_2,zone_2,,,,DEG_F,,
+tstat_zone_3,zone_3,,,,DEG_F,,
+,,,,,,,

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/config.json
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/config.json
@@ -1,0 +1,41 @@
+{
+    "site_id": "hpflex_demo",
+    "hvac_type": "hp-rtu",
+    "hvacs_feed_hvacs": {},
+    "hvacs_feed_zones": {
+        "hvac_1": [
+            "zone_1"
+        ],
+        "hvac_2": [
+            "zone_2"
+        ],
+        "hvac_3": [
+            "zone_3"
+        ]
+    },
+    "zones_contain_spaces": {
+        "zone_1": [
+            "space_1_1"
+        ],
+        "zone_2": [
+            "space_2_1"
+        ],
+        "zone_3": [
+            "space_3_1"
+        ]
+    },
+    "zones_contain_windows": {
+        "zone_1": [
+            "window_1_1"
+        ],
+        "zone_2": [
+            "window_2_1",
+            "window_2_2"
+        ],
+        "zone_3": [
+            "window_3_1",
+            "window_3_2",
+            "window_3_3"
+        ]
+    }
+}

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/hvac/hvac_units.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/hvac/hvac_units.csv
@@ -1,0 +1,4 @@
+hvac_id,zone_id,cooling_capacity,heating_capacity,cooling_cop,heating_cop
+hvac_1,zone_1,-7.5,10,2.5,2.94
+hvac_2,zone_2,-7.5,10,2.5,2.94
+hvac_3,zone_3,-7.5,10,2.5,2.94

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/point_list.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/point_list.csv
@@ -1,0 +1,1 @@
+point_of,point_type,point_name,quantitykind,unit

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/site_info.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/site_info.csv
@@ -1,0 +1,2 @@
+site_id,timezone,latitude,longitude,noaa_station
+hpflex_demo,US/Pacific,37.879134,-122.254433,

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/spaces/zone_1_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/spaces/zone_1_spaces.csv
@@ -1,0 +1,2 @@
+space_id,zone_id,area_value,area_unit
+space_1_1,zone_1,1300,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/spaces/zone_2_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/spaces/zone_2_spaces.csv
@@ -1,0 +1,2 @@
+space_id,zone_id,area_value,area_unit
+space_2_1,zone_2,1300,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/spaces/zone_3_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/spaces/zone_3_spaces.csv
@@ -1,0 +1,2 @@
+space_id,zone_id,area_value,area_unit
+space_3_1,zone_3,1300,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/windows/zone_1_windows.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/windows/zone_1_windows.csv
@@ -1,0 +1,2 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_1_1,zone_1,150,180,90,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/windows/zone_2_windows.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/windows/zone_2_windows.csv
@@ -1,0 +1,3 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_2_1,zone_2,80,180,90,FT2
+window_2_2,zone_2,80,180,90,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/windows/zone_3_windows.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/windows/zone_3_windows.csv
@@ -1,0 +1,4 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_3_1,zone_3,50,180,90,FT2
+window_3_2,zone_3,50,180,90,FT2
+window_3_3,zone_3,50,180,90,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/zones/zones.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg1/zones/zones.csv
@@ -1,0 +1,4 @@
+tstat_id,zone_id,stage_count,setpoint_deadband,tolerance,active,resolution,temperature_unit
+tstat_zone_1,zone_1,4,0.5,0.5,TRUE,float,DEG_F
+tstat_zone_2,zone_2,4,0.5,0.5,TRUE,float,DEG_F
+tstat_zone_3,zone_3,4,0.5,0.5,TRUE,float,DEG_F

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/config.json
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/config.json
@@ -1,0 +1,47 @@
+{
+    "site_id": "hpflex_demo",
+    "hvac_type": "hp-rtu",
+    "hvacs_feed_hvacs": {},
+    "hvacs_feed_zones": {
+        "hvac_1": [
+            "zone_1"
+        ],
+        "hvac_2": [
+            "zone_2"
+        ],
+        "hvac_3": [
+            "zone_3"
+        ],
+        "hvac_4": [
+            "zone_4"
+        ]
+    },
+    "zones_contain_spaces": {
+        "zone_1": [
+            "space_1_1"
+        ],
+        "zone_2": [
+            "space_2_1"
+        ],
+        "zone_3": [
+            "space_3_1"
+        ],
+        "zone_4": [
+            "space_4_1"
+        ]
+    },
+    "zones_contain_windows": {
+        "zone_1": [
+            "window_1_1"
+        ],
+        "zone_2": [
+            "window_2_1"
+        ],
+        "zone_3": [
+            "window_3_1"
+        ],
+        "zone_4": [
+            "window_4_1"
+        ]
+    }
+}

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/hvac/hvac_units.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/hvac/hvac_units.csv
@@ -1,0 +1,5 @@
+hvac_id,zone_id,cooling_capacity,heating_capacity,cooling_cop,heating_cop
+hvac_1,zone_1,-7.5,10,2.5,2.94
+hvac_2,zone_2,-7.5,10,2.5,2.94
+hvac_3,zone_3,-7.5,10,2.5,2.94
+hvac_4,zone_4,-7.5,10,2.5,2.94

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/point_list.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/point_list.csv
@@ -1,0 +1,1 @@
+point_of,point_type,point_name,quantitykind,unit

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/site_info.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/site_info.csv
@@ -1,0 +1,2 @@
+site_id,timezone,latitude,longitude,noaa_station
+hpflex_demo,US/Pacific,37.879134,-122.254433,

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/spaces/zone_1_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/spaces/zone_1_spaces.csv
@@ -1,0 +1,2 @@
+space_id,zone_id,area_value,area_unit
+space_1_1,zone_1,1500,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/spaces/zone_2_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/spaces/zone_2_spaces.csv
@@ -1,0 +1,2 @@
+space_id,zone_id,area_value,area_unit
+space_2_1,zone_2,1500,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/spaces/zone_3_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/spaces/zone_3_spaces.csv
@@ -1,0 +1,2 @@
+space_id,zone_id,area_value,area_unit
+space_3_1,zone_3,1500,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/spaces/zone_4_spaces.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/spaces/zone_4_spaces.csv
@@ -1,0 +1,2 @@
+space_id,zone_id,area_value,area_unit
+space_4_1,zone_4,1500,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/windows/zone_1_windows.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/windows/zone_1_windows.csv
@@ -1,0 +1,2 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_1_1,zone_1,150,180,90,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/windows/zone_2_windows.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/windows/zone_2_windows.csv
@@ -1,0 +1,2 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_2_1,zone_2,150,180,90,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/windows/zone_3_windows.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/windows/zone_3_windows.csv
@@ -1,0 +1,2 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_3_1,zone_3,150,180,90,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/windows/zone_4_windows.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/windows/zone_4_windows.csv
@@ -1,0 +1,2 @@
+window_id,zone_id,area_value,azimuth_value,tilt_value,area_unit
+window_4_1,zone_4,150,180,90,FT2

--- a/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/zones/zones.csv
+++ b/tutorial/metadata-survey-hpflex/hpflex_demo/bldg2/zones/zones.csv
@@ -1,0 +1,5 @@
+tstat_id,zone_id,stage_count,setpoint_deadband,tolerance,active,resolution,temperature_unit
+tstat_zone_1,zone_1,1,4,0.5,TRUE,float,DEG_F
+tstat_zone_2,zone_2,1,4,0.5,TRUE,float,DEG_F
+tstat_zone_3,zone_3,1,4,0.5,TRUE,float,DEG_F
+tstat_zone_4,zone_4,1,4,0.5,TRUE,float,DEG_F

--- a/tutorial/testing_hpflex.ipynb
+++ b/tutorial/testing_hpflex.ipynb
@@ -1,0 +1,752 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(0, '..')\n",
+    "from BrickModelInterface import BrickModelBuilder, BuildingMetadataLoader, add_points, SurveyGenerator, SurveyReader\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "survey_gen = SurveyGenerator(site_id = 'hpflex_demo',\n",
+    "                             building_id = 'bldg1',\n",
+    "                             hvac_type = 'hp-rtu')\n",
+    "# zone_space_window list for configuration: 3 zones, with 2 spaces and 2 windows, 1 space and 2 windows, 1 space 3 windows, one hvac unit per zone\n",
+    "#survey_gen.easy_config(zone_space_window_list=[(2,2),(1,2),(1,3)], output_path='./metadata-survey-hpflex')\n",
+    "\n",
+    "# bldg 1\n",
+    "survey_gen.easy_config(zone_space_window_list=[(1,1),(1,2),(1,3)], output_path='./metadata-survey-hpflex')\n",
+    "\n",
+    "survey_gen = SurveyGenerator(site_id = 'hpflex_demo',\n",
+    "                             building_id = 'bldg2',\n",
+    "                             hvac_type = 'hp-rtu')\n",
+    "# bldg 2\n",
+    "survey_gen.easy_config(zone_space_window_list=[(1,1),(1,1),(1,1),(1,1)], output_path='./metadata-survey-hpflex')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/pyshacl/extras/__init__.py:46: Warning: Extra \"js\" is not satisfied because requirement pyduktape2 is not installed.\n",
+      "  warn(Warning(f\"Extra \\\"{extra_name}\\\" is not satisfied because requirement {req} is not installed.\"))\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (1,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (2,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (3,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (4,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (5,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (6,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (7,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (8,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (9,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (10,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (11,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (12,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (13,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (14,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (15,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (16,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (17,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (18,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (19,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (20,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (21,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (22,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (23,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (24,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (25,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n"
+     ]
+    }
+   ],
+   "source": [
+    "generator = SurveyReader(\"./metadata-survey-hpflex/hpflex_demo/bldg1\")\n",
+    "generator.create_model(\"bldg1.ttl\")\n",
+    "\n",
+    "generator = SurveyReader(\"./metadata-survey-hpflex/hpflex_demo/bldg2\")\n",
+    "generator.create_model(\"bldg2.ttl\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "site_metadata = BuildingMetadataLoader(\"test-brick-model.ttl\",ontology='brick')\n",
+    "site_info = site_metadata.get_site_info()\n",
+    "thermostat_data = site_metadata.get_thermostat_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tz': 'urn:hpflex/test-site#test-site.timezone',\n",
+       " 'latitude': 'urn:hpflex/test-site#test-site.latitude',\n",
+       " 'longitude': 'urn:hpflex/test-site#test-site.longitude',\n",
+       " 'NOAAstation': 'urn:hpflex/test-site#test-site.noaastation',\n",
+       " 'project_id': rdflib.term.URIRef('urn:hpflex/test-site#test-site'),\n",
+       " 'site_id': rdflib.term.URIRef('urn:hpflex/test-site#test-site')}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "site_info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'heat_availability': [False, False],\n",
+       " 'cool_availability': [True, True],\n",
+       " 'heat_tolerance': [-2.0, -2.0],\n",
+       " 'cool_tolerance': [2.0, 2.0],\n",
+       " 'setpoint_deadband': [1, 1],\n",
+       " 'active': [True, True],\n",
+       " 'control_group': ['DEPRECATED', 'DEPRECATED'],\n",
+       " 'control_type_list': ['stage', 'stage'],\n",
+       " 'floor_area_list': [50.0, 50.0],\n",
+       " 'window_area_list': [10.5, 10.5],\n",
+       " 'azimuth_list': [180, 180],\n",
+       " 'tilt_list': [30, 30],\n",
+       " 'zone_ids': ['zone1', 'zone2'],\n",
+       " 'hvacs': ['hvac1', 'hvac2'],\n",
+       " 'setpoint_type': ['double', 'double'],\n",
+       " 'fuel_heat_list': ['gas', 'gas'],\n",
+       " 'fuel_cool_list': ['electricity', 'electricity'],\n",
+       " 'cooling_capacity': [5.0, 5.0],\n",
+       " 'heating_capacity': [4.0, 4.0],\n",
+       " 'cooling_cop': [3.5, 3.5],\n",
+       " 'heating_cop': [3.0, 3.0],\n",
+       " 'cooling_electricity': [],\n",
+       " 'heating_electricity': [],\n",
+       " 'resolution': [1, 1],\n",
+       " 'temperature_unit': [rdflib.term.URIRef('http://qudt.org/vocab/unit/DEG_F'),\n",
+       "  rdflib.term.URIRef('http://qudt.org/vocab/unit/DEG_F')]}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thermostat_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing the Model Builder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/anaconda3/envs/hpflex_mpc/lib/python3.11/site-packages/pyshacl/extras/__init__.py:46: Warning: Extra \"js\" is not satisfied because requirement pyduktape2 is not installed.\n",
+      "  warn(Warning(f\"Extra \\\"{extra_name}\\\" is not satisfied because requirement {req} is not installed.\"))\n"
+     ]
+    }
+   ],
+   "source": [
+    "builder = BrickModelBuilder(\n",
+    "    site_id=\"test-site\",\n",
+    "    timezone=\"America/New_York\",\n",
+    "    latitude=40.7128,\n",
+    "    longitude=-74.0060,\n",
+    "    noaa_station=\"KJFK\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zone1\n",
+      "zone2\n"
+     ]
+    }
+   ],
+   "source": [
+    "builder.add_zone(\"zone1\")\n",
+    "builder.add_window(\"window1\", \"zone1\", area_value=10.5, azimuth_value=180, tilt_value=30)\n",
+    "builder.add_thermostat(\"tstat1\", \"zone1\", stage_count=2, setpoint_deadband=1, tolerance=2, active=True, resolution = \"float\",unit=\"IP\")\n",
+    "builder.add_hvac(\"hvac1\", \"zone1\", cooling_capacity=5.0, heating_capacity=4.0, cooling_cop=3.5, heating_cop=3.0)\n",
+    "builder.add_space(\"space1\", \"zone1\", area_value=50.0)\n",
+    "\n",
+    "builder.add_zone(\"zone2\")\n",
+    "builder.add_window(\"window2\", \"zone2\", area_value=10.5, azimuth_value=180, tilt_value=30)\n",
+    "builder.add_thermostat(\"tstat2\", \"zone2\", stage_count=2, setpoint_deadband=1, tolerance=2, active=True, resolution =  \"float\",unit=\"IP\")\n",
+    "builder.add_hvac(\"hvac2\", \"zone2\", cooling_capacity=5.0, heating_capacity=4.0, cooling_cop=3.5, heating_cop=3.0)\n",
+    "builder.add_space(\"space2\", \"zone2\", area_value=50.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using AQL for proof of concept, this part is incomplete\n",
+    "add_points(builder, \"../development_files/metadata-survey-variable-map.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "builder.save_model(\"test-brick-model.ttl\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing get Metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'BuildingMetadataLoader' object has no attribute 'BRICK'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[6], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m site_metadata \u001b[38;5;241m=\u001b[39m BuildingMetadataLoader(source\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m/Users/srgmac/SemanticModelBuilder/tutorial/bldg1.ttl\u001b[39m\u001b[38;5;124m\"\u001b[39m,ontology\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mbrick\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m----> 2\u001b[0m site_info \u001b[38;5;241m=\u001b[39m \u001b[43msite_metadata\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_site_info\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      3\u001b[0m thermostat_data \u001b[38;5;241m=\u001b[39m site_metadata\u001b[38;5;241m.\u001b[39mget_thermostat_data()\n",
+      "File \u001b[0;32m~/SemanticModelBuilder/tutorial/../BrickModelInterface/get_metadata.py:262\u001b[0m, in \u001b[0;36mBuildingMetadataLoader.get_site_info\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    259\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Fetch site-level metadata.\"\"\"\u001b[39;00m\n\u001b[1;32m    260\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39montology \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mbrick\u001b[39m\u001b[38;5;124m'\u001b[39m:\n\u001b[1;32m    261\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m{\n\u001b[0;32m--> 262\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtz\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_value(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msite, \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mBRICK\u001b[49m\u001b[38;5;241m.\u001b[39mtimezone),\n\u001b[1;32m    263\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mlatitude\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_value(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msite, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mBRICK\u001b[38;5;241m.\u001b[39mlatitude),\n\u001b[1;32m    264\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mlongitude\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_value(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msite, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mBRICK\u001b[38;5;241m.\u001b[39mlongitude),\n\u001b[1;32m    265\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mNOAAstation\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_value(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msite, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mBRICK\u001b[38;5;241m.\u001b[39mhasNOAAStation),\n\u001b[1;32m    266\u001b[0m     \u001b[38;5;66;03m# project_id and site_id are currently the same\u001b[39;00m\n\u001b[1;32m    267\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mproject_id\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;28mnext\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mg\u001b[38;5;241m.\u001b[39mtriples((\u001b[38;5;28;01mNone\u001b[39;00m,RDF\u001b[38;5;241m.\u001b[39mtype, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mBRICK\u001b[38;5;241m.\u001b[39mSite)))[\u001b[38;5;241m0\u001b[39m],\n\u001b[1;32m    268\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msite_id\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;28mnext\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mg\u001b[38;5;241m.\u001b[39mtriples((\u001b[38;5;28;01mNone\u001b[39;00m,RDF\u001b[38;5;241m.\u001b[39mtype, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mBRICK\u001b[38;5;241m.\u001b[39mSite)))[\u001b[38;5;241m0\u001b[39m],\n\u001b[1;32m    269\u001b[0m }\n\u001b[1;32m    270\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    271\u001b[0m     results \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mg\u001b[38;5;241m.\u001b[39mquery(sparql_queries[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msite_info\u001b[39m\u001b[38;5;124m\"\u001b[39m][\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39montology])\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'BuildingMetadataLoader' object has no attribute 'BRICK'"
+     ]
+    }
+   ],
+   "source": [
+    "site_metadata = BuildingMetadataLoader(source=\"/Users/srgmac/SemanticModelBuilder/tutorial/bldg1.ttl\",ontology='brick')\n",
+    "site_info = site_metadata.get_site_info()\n",
+    "thermostat_data = site_metadata.get_thermostat_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'heat_availability': [False, False],\n",
+       " 'cool_availability': [True, True],\n",
+       " 'heat_tolerance': [-1.111111, -1.111111],\n",
+       " 'cool_tolerance': [1.111111, 1.111111],\n",
+       " 'setpoint_deadband': [0.5555556, 0.5555556],\n",
+       " 'active': [True, True],\n",
+       " 'control_group': ['urn:hpflex/test-site#tstat1_control_group',\n",
+       "  'urn:hpflex/test-site#tstat2_control_group'],\n",
+       " 'control_type_list': ['stage', 'stage'],\n",
+       " 'floor_area_list': [50.0, 50.0],\n",
+       " 'window_area_list': [10.5, 10.5],\n",
+       " 'azimuth_list': [180, 180],\n",
+       " 'tilt_list': [30, 30],\n",
+       " 'zone_ids': ['zone1', 'zone2'],\n",
+       " 'hvacs': ['hvac1', 'hvac2'],\n",
+       " 'setpoint_type': ['double', 'double'],\n",
+       " 'fuel_heat_list': ['gas', 'gas'],\n",
+       " 'fuel_cool_list': ['electricity', 'electricity'],\n",
+       " 'cooling_capacity': [5.0, 5.0],\n",
+       " 'heating_capacity': [4.0, 4.0],\n",
+       " 'cooling_cop': [3.5, 3.5],\n",
+       " 'heating_cop': [3.0, 3.0],\n",
+       " 'cooling_electricity': [],\n",
+       " 'heating_electricity': [],\n",
+       " 'resolution': ['float', 'float'],\n",
+       " 'temperature_unit': [rdflib.term.URIRef('http://qudt.org/vocab/unit/DEG_F'),\n",
+       "  rdflib.term.URIRef('http://qudt.org/vocab/unit/DEG_F')]}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thermostat_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'heat_availability': [False],\n",
+       " 'cool_availability': [True],\n",
+       " 'heat_tolerance': [-1.111111],\n",
+       " 'cool_tolerance': [1.111111],\n",
+       " 'setpoint_deadband': [0.5555556],\n",
+       " 'active': [True],\n",
+       " 'control_group': ['urn:hpflex/test-site#tstat1_control_group'],\n",
+       " 'control_type_list': ['stage'],\n",
+       " 'floor_area_list': [50.0],\n",
+       " 'window_area_list': [10.5],\n",
+       " 'azimuth_list': [180],\n",
+       " 'tilt_list': [30],\n",
+       " 'zone_ids': ['zone1'],\n",
+       " 'hvacs': ['hvac1'],\n",
+       " 'setpoint_type': ['double'],\n",
+       " 'fuel_heat_list': ['gas'],\n",
+       " 'fuel_cool_list': ['electricity'],\n",
+       " 'cooling_capacity': [5.0],\n",
+       " 'heating_capacity': [4.0],\n",
+       " 'cooling_cop': [3.5],\n",
+       " 'heating_cop': [3.0],\n",
+       " 'cooling_electricity': [],\n",
+       " 'heating_electricity': [],\n",
+       " 'resolution': ['float'],\n",
+       " 'temperature_unit': [rdflib.term.URIRef('http://qudt.org/vocab/unit/DEG_F')]}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "site_metadata.get_thermostat_data(for_zone='zone1')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tz': 'America/New_York',\n",
+       " 'latitude': 40.7128,\n",
+       " 'longitude': -74.006,\n",
+       " 'NOAAstation': None,\n",
+       " 'project_id': rdflib.term.URIRef('urn:hpflex/test-site#test-site'),\n",
+       " 'site_id': rdflib.term.URIRef('urn:hpflex/test-site#test-site'),\n",
+       " 'heat_availability': [False, False],\n",
+       " 'cool_availability': [True, True],\n",
+       " 'heat_tolerance': [-1.111111, -1.111111],\n",
+       " 'cool_tolerance': [1.111111, 1.111111],\n",
+       " 'setpoint_deadband': [0.5555556, 0.5555556],\n",
+       " 'active': [True, True],\n",
+       " 'control_group': ['urn:hpflex/test-site#tstat1_control_group',\n",
+       "  'urn:hpflex/test-site#tstat2_control_group'],\n",
+       " 'control_type_list': ['stage', 'stage'],\n",
+       " 'floor_area_list': [50.0, 50.0],\n",
+       " 'window_area_list': [10.5, 10.5],\n",
+       " 'azimuth_list': [180, 180],\n",
+       " 'tilt_list': [30, 30],\n",
+       " 'zone_ids': ['zone1', 'zone2'],\n",
+       " 'hvacs': ['hvac1', 'hvac2'],\n",
+       " 'setpoint_type': ['double', 'double'],\n",
+       " 'fuel_heat_list': ['gas', 'gas'],\n",
+       " 'fuel_cool_list': ['electricity', 'electricity'],\n",
+       " 'cooling_capacity': [5.0, 5.0],\n",
+       " 'heating_capacity': [4.0, 4.0],\n",
+       " 'cooling_cop': [3.5, 3.5],\n",
+       " 'heating_cop': [3.0, 3.0],\n",
+       " 'cooling_electricity': [],\n",
+       " 'heating_electricity': [],\n",
+       " 'resolution': ['float', 'float'],\n",
+       " 'temperature_unit': [rdflib.term.URIRef('http://qudt.org/vocab/unit/DEG_F'),\n",
+       "  rdflib.term.URIRef('http://qudt.org/vocab/unit/DEG_F')]}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "site_metadata.get_complete_output()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generating Metadata Survey"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Old version\n",
+    "# interface = SurveyGenerator(\n",
+    "#     site_name=\"empty-test-site\",\n",
+    "#     num_zones=3,\n",
+    "#     spaces_per_zone=2,\n",
+    "#     num_hvac_units=2,\n",
+    "#     one_hvac_per_zone=True,\n",
+    "#     hvac_type=\"hp-rtu\"\n",
+    "# )\n",
+    "#interface.generate_template(\"./metadata-survey\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "survey_gen = SurveyGenerator(site_name = 'easy-config-test',\n",
+    "                             hvac_type = 'hp-rtu')\n",
+    "# zone_space_window list for configuration: 3 zones, with 2 spaces and 2 windows, 1 space and 2 windows, 1 space 3 windows, one hvac unit per zone\n",
+    "survey_gen.easy_config(zone_space_window_list=[(2,2),(1,2),(1,3)], output_path='./metadata-survey')\n",
+    "# survey_gen.easy_config(zone_space_window_list=[(1,1)], output_path='./metadata-survey')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Custom config \n",
+    "# TODO: add underscores to begining of all methods but generate template and easy config\n",
+    "survey_gen = SurveyGenerator(site_name= 'custom-config-test',\n",
+    "                             hvac_type = 'vrf')\n",
+    "survey_gen.generate_template(\n",
+    "    hvacs_feed_hvacs = {'HP1': ['FCU1','FCU2','FCU3'],\n",
+    "                        'HP2': ['FCU1', 'FCU2', 'FCU3']},\n",
+    "    hvacs_feed_zones= {'FCU1': ['Zone1'],\n",
+    "                       'FCU2': ['Zone2'],\n",
+    "                       'FCU3': ['Zone3']},\n",
+    "    zones_contain_spaces= {'Zone1': ['Z1S1', 'Z1S2'],\n",
+    "                           'Zone2': ['Z1S2','Z2S3'],\n",
+    "                           'Zone3': ['Z3S1']},\n",
+    "    zones_contain_windows= {'Zone1': ['W1'],\n",
+    "                           'Zone2': ['W2'],\n",
+    "                           'Zone3': ['W3','W4','W5','W6']},\n",
+    "                           output_path='./metadata-survey'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reading Metadata Survey"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (1,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (2,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (3,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (4,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (5,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (6,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (7,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (8,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (9,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (10,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (11,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (12,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (13,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n",
+      "/opt/anaconda3/envs/bmotif/lib/python3.11/site-packages/buildingmotif/database/table_connection.py:423: SAWarning: Identity map already had an identity for (<class 'buildingmotif.database.tables.DepsAssociation'>, (14,), None), replacing it with newly flushed object.   Are there load operations occurring inside of an event handler within the flush?\n",
+      "  self.bm.session.flush()\n"
+     ]
+    }
+   ],
+   "source": [
+    "generator = SurveyReader(\"./metadata-survey/filled-out-easy-config-test\")\n",
+    "generator.create_model(\"survey-brick-model.ttl\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'hvac_1': ['zone_1']}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generator.config['hvacs_feed_zones']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zones=[]\n",
+    "with open(\"/Users/srgmac/SemanticModelBuilder/tutorial/metadata-survey-hpflex/filled-easy-config-test/zones/zones.csv\", 'r') as f:\n",
+    "    reader = csv.DictReader(f)\n",
+    "    for row in reader:\n",
+    "        zones.append(row)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tstat_id': 'tstat_zone_1',\n",
+       " 'zone_id': 'zone_1',\n",
+       " 'stage_count': '',\n",
+       " 'setpoint_deadband': '',\n",
+       " 'tolerance': '',\n",
+       " 'active': 'DEG_F',\n",
+       " 'resolution': '',\n",
+       " 'temperature_unit': ''}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zones[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "''"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zones[3]['tstat_id']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tstat_id': '',\n",
+       " 'zone_id': '',\n",
+       " 'stage_count': '',\n",
+       " 'setpoint_deadband': '',\n",
+       " 'tolerance': '',\n",
+       " 'active': '',\n",
+       " 'resolution': '',\n",
+       " 'temperature_unit': ''}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zones[3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hpflex_mpc",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- convert `site_name` to `site_id` to align with zone_id, hvac_id, etc.
- Add `building_id` as the current semantic building is based on building-level. So, for a site, there can be multiple buildings.
- add validate csv rows in `read_metadata_survey` so that it checks all rows are filled (except for noaastation). 